### PR TITLE
Configure optimized compilation for Rust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ CFLAGS=-O3
 code: code.c
 
 code_rs: code.rs
-	-rustc -o code_rs code.rs
+	-rustc --codegen opt-level=3 -o code_rs code.rs
 
 .SUFFIXES: .java .class
 .java.class:


### PR DESCRIPTION
Since `CFLAGS=-O3` has been configured for C compilation, the same level of compilation can be configured for Rust to compare similar things.